### PR TITLE
fix: watcherHandler is stopped when needed

### DIFF
--- a/src/recording-page.ts
+++ b/src/recording-page.ts
@@ -133,7 +133,9 @@ export class RecordingPage implements Page {
 
     private async onEndClick() {
         this._locationManager.stopWatch();
-        this._orientationManager.unwatch(this.onOrientationChange);
+        if (this._wathchHandler) {
+            this._orientationManager.unwatch(this._wathchHandler);
+        }
         const session = this._sessionDraft?.end();
         await this._router.navigate("summary", {
             session


### PR DESCRIPTION
- unwatch function was taking wrong parameter