### PR TITLE
fix: gamma can be calculated for no location access case

### DIFF
--- a/src/pages/recording-page.ts
+++ b/src/pages/recording-page.ts
@@ -110,6 +110,10 @@ export class RecordingPage implements Page {
       this.onOrientationChange.bind(this),
     );
 
+    if (!this._locationManager.isLocationAccessGranted) {
+      this._sessionDraft?.findMaxGamma();
+    }
+
     return canvas;
   }
 

--- a/src/services/session-draft.ts
+++ b/src/services/session-draft.ts
@@ -27,6 +27,30 @@ export class SessionDraft {
     this._orientations.push(correctedGammaWith90deg);
   }
 
+  findMaxGamma() {
+    setInterval(() => {
+      let gammaMax = 0;
+
+      for (const orientation of this._orientations) {
+        if (orientation > gammaMax) {
+          gammaMax = orientation;
+        }
+      }
+
+      if (Math.abs(gammaMax) > Math.abs(this._maxLeanAngle)) {
+        this._maxLeanAngle = gammaMax;
+      }
+
+      const point: Point = {
+        date: this._startTime,
+        gamma: gammaMax,
+      };
+
+      this._points.push(point);
+      this._orientations = [];
+    }, 500);
+  }
+
   addLocation(position: GeolocationPosition) {
     let gammaMax = 0;
 
@@ -86,15 +110,17 @@ export class SessionDraft {
   }
 
   private calcDistance(point: Point, prevPoint: Point): number {
-    let latFirst = prevPoint.latitude;
-    latFirst = this.deg2rad(latFirst);
-    let latLast = point.latitude;
-    latLast = this.deg2rad(latLast);
+    let latFirst = 0;
+    let latLast = 0;
+    latFirst = prevPoint.latitude ? this.deg2rad(prevPoint.latitude) : latFirst;
+    latLast = point.latitude ? this.deg2rad(point.latitude) : latFirst;
 
-    let lngFirst = prevPoint.longitude;
-    lngFirst = this.deg2rad(lngFirst);
-    let lngLast = point.longitude;
-    lngLast = this.deg2rad(lngLast);
+    let lngFirst = 0;
+    let lngLast = 0;
+    lngFirst = prevPoint.longitude
+      ? this.deg2rad(prevPoint.longitude)
+      : lngFirst;
+    lngLast = point.longitude ? this.deg2rad(point.longitude) : lngLast;
 
     const earthRadius = 6371; // Radius of the earth in km
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,11 @@ export interface Page<TOptions = unknown> {
 
 export interface Point {
   date: number;
-  latitude: number;
-  longitude: number;
-  timestamp: number;
-  speed: number;
-  distance: number;
+  latitude?: number;
+  longitude?: number;
+  timestamp?: number;
+  speed?: number;
+  distance?: number;
   gamma: number;
 }
 


### PR DESCRIPTION
- `Point` type is updated to make it suitable for the no location access case.
- calc distance function is updated according to the updated type `Point`