### PR TITLE
fix: `npm run format` is missing html files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bundle": "webpack --mode=production",
     "start": "webpack serve --open",
     "lint": "eslint",
-    "format": "prettier --ignore-path .gitignore --write ."
+    "format": "prettier --write ."
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bundle": "webpack --mode=production",
     "start": "webpack serve --open",
     "lint": "eslint",
-    "format": "prettier --ignore-path .gitignore --write 'src/**/*.+(js|ts|json)'"
+    "format": "prettier --ignore-path .gitignore --write ."
   },
   "author": "",
   "license": "ISC",

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,22 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+  <head>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
+    />
     <title>MotoPerf</title>
-    <link rel="manifest" href="site.webmanifest" crossorigin="use-credentials" />
-</head>
+    <link
+      rel="manifest"
+      href="site.webmanifest"
+      crossorigin="use-credentials"
+    />
+  </head>
 
-<body>
-    <div id="root" class="root-div d-flex flex-column justify-content-center text-body"></div>
-</body>
-
+  <body>
+    <div
+      id="root"
+      class="root-div d-flex flex-column justify-content-center text-body"
+    ></div>
+  </body>
 </html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
-    "module": "ESNext", /* Specify what module code is generated. */
+    "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -55,7 +55,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./lib", /* Specify an output folder for all emitted files. */
+    "outDir": "./lib" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -74,12 +74,12 @@
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
     /* Type Checking */
-    "strict": true, /* Enable all strict type-checking options. */
-    "noImplicitAny": true, /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
@@ -102,7 +102,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": [
-    "src",
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
`npm run format` used to check/fix only .ts,.js,.json files. Therefore it wasn't fixing html files. However, vscode prettier extension used to run on all files. 
In order to have alignment, I made `format` to run with all the files in the directory. This lead fixing tsconfig and html file. 

- Removed unnecessary --ignore-paths arg from `format` script as it ignores all the files in the .gitignore by default.  